### PR TITLE
notify onReady after updating graph (not before)

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,13 +37,6 @@ module.exports = function (options) {
       ready ++
       return function update (from, to, value) {
         if(isObject(from)) {
-          if(!isReady[name]) {
-            isReady[name] = true
-            ready --
-            if(ready === 0) {
-              while(readyListeners.length) readyListeners.shift()()
-            }
-          }
           var g = from
           layers[index] = g
           layers.forEach(function (g) {
@@ -56,6 +49,13 @@ module.exports = function (options) {
           _graph = d.reverse(graph)
           hops = d.traverse(graph, _graph, options.max, options.start)
           notify(hops)
+          if(!isReady[name]) {
+            isReady[name] = true
+            ready --
+            if(ready === 0) {
+              while(readyListeners.length) readyListeners.shift()()
+            }
+          }
         }
         else {
           layers[index][from] = layers[index][from] || {}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "dynamic-dijkstra": "^1.0.0",
     "pull-cont": "^0.1.1",
-    "pull-notify": "^0.1.1"
+    "pull-notify": "^0.1.1",
+    "pull-stream": "^3.6.9"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
If you start an async call in `ssb-friends` while indexing is still in progress (e.g. `hops` via `onReady`), it won't return until after the indexing completes, however **the result still does not have any data**. This is because `onReady` is getting called before actually saving the index result. This makes the initial load/upgrade state broken in Patchwork.

**This PR fixes the ordering so that `onReady` does not get called until after the result has been saved.**