### PR TITLE
Do once after layer is ready, so we get the final value for old

### DIFF
--- a/index.js
+++ b/index.js
@@ -129,10 +129,14 @@ module.exports = function (options) {
           })
         })
       }
-      else
-        source = Once(hops)
-
-      return source
+      else {
+        return pCont(function (cb) {
+          layered.onReady(function () {
+            source = Once(hops)
+            cb(null, source)
+          })
+        })
+      }
     },
     getGraph: function (name) {
       if(name == null) return graph


### PR DESCRIPTION
I noticed that when running plugins such as ssb-friend-pub with old: true and live: false I would only get myself as the state. This seems to be because ssb-friends hasn't done loading the layer before doing the callback.