### PR TITLE
add reset() API

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ call `fn` back once all layers have been initialized, or immediately if they are
 
 call `fn` when an edge is added or removed from the graph.
 
+### layers.reset()
+
+Clear the state held by this instance, basically going back to how things were
+when you called `LayeredGraph({start, max})`.
+
 ## License
 
 MIT

--- a/index.js
+++ b/index.js
@@ -153,5 +153,15 @@ module.exports = function (options) {
       if (name == null) return graph
       else return layers[byName[name]]
     },
+    reset: function () {
+      byName = {}
+      layers = []
+      graph = {}
+      _graph = {}
+      hops = {}
+      ready = 0
+      hops[options.start] = simple.initial()
+      isReady = {}
+    },
   })
 }

--- a/test/index.js
+++ b/test/index.js
@@ -53,6 +53,9 @@ tape('simple', function (t) {
   t.equal(count, 3)
   t.deepEqual(last, { C: -1 })
 
+  G.reset()
+  t.deepEqual(G.getGraph(), {})
+
   t.end()
 })
 


### PR DESCRIPTION
Needed by ssb-friends's db2Contacts reset() function after deletes and after compaction, because we have to reset internal state.